### PR TITLE
feat(github-runner): self hosted runner compatible

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,9 +35,10 @@ runs:
       shell: bash
       run: |
         if ! command -v pipx &> /dev/null; then
-          sudo apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install pipx -y
-          pipx ensurepath
+          python3 -m pip --upgrade pip
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         fi
     - name: Install CLI
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -15,13 +15,13 @@ inputs:
       
       Pass `secrets.GITHUB_TOKEN` context to this input
       (https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context)
-
+      
       The job where this action is called needs
       ```
       permissions:
         actions: read
       ```
-
+      
       https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     required: false
 outputs:

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         if ! command -v pipx &> /dev/null; then
-          python3 -m pip --upgrade pip
+          python3 -m pip install --upgrade pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install python3-venv if not available
+      shell: bash
+      run: |
+        if ! dpkg -s python3-venv &> /dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y python3-venv
+        fi
     - name: Install pipx if not available
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
       permissions:
         actions: read
       ```
-
+      
       https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     required: false
 outputs:

--- a/action.yaml
+++ b/action.yaml
@@ -10,9 +10,9 @@ inputs:
   github-token:
     description: |
       GitHub token
-
+      
       Required for private repositories (for GitHub API call)
-
+      
       Pass `secrets.GITHUB_TOKEN` context to this input
       (https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context)
 
@@ -21,7 +21,7 @@ inputs:
       permissions:
         actions: read
       ```
-      
+
       https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     required: false
 outputs:

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install pipx if not available
+      shell: bash
+      run: |
+        if ! command -v pipx &> /dev/null; then
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        fi
     - name: Install CLI
       shell: bash
       run: pipx install "${VAR_ACTION_PATH}"

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
       run: |
         if ! command -v pipx &> /dev/null; then
           sudo apt update
-          sudo apt install pipx
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install pipx -y
           pipx ensurepath
         fi
     - name: Install CLI

--- a/action.yaml
+++ b/action.yaml
@@ -10,18 +10,18 @@ inputs:
   github-token:
     description: |
       GitHub token
-      
+
       Required for private repositories (for GitHub API call)
-      
+
       Pass `secrets.GITHUB_TOKEN` context to this input
       (https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context)
-      
+
       The job where this action is called needs
       ```
       permissions:
         actions: read
       ```
-      
+
       https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     required: false
 outputs:
@@ -35,9 +35,9 @@ runs:
       shell: bash
       run: |
         if ! command -v pipx &> /dev/null; then
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          sudo apt update
+          sudo apt install pipx
+          pipx ensurepath
         fi
     - name: Install CLI
       shell: bash


### PR DESCRIPTION
GitHub self-hosted runners run by Canonical do not match 100% parity with GitHub provided runners.

This PR aims to support get-workflow-version workflow on the self-hosted runners.

Link to successful workflow: https://github.com/canonical/github-runner-image-builder-operator/actions/runs/24353953465/job/71115757324?pr=213#step:8:1